### PR TITLE
Added a translateZ transform for the element being dragged

### DIFF
--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -576,9 +576,15 @@ export default Mixin.create({
       let y = this.get('y');
       let dy = y - this.element.offsetTop;
 
-      this.$().css({
-        transform: `translateY(${dy}px)`
-      });
+		if (this.get('isDragging')) {
+			this.$().css({
+			  transform: `translateY(${dy}px) translateZ(1em)`
+			});
+		} else {
+			this.$().css({
+				transform: `translateY(${dy}px)`
+			});
+		}
     }
   },
 


### PR DESCRIPTION
This might not be quite the right way to do this but I've noticed that dragging taller list elements over other list elements sometimes caused them to drop behind (or at least level with) that element. Doing some research it seems that when a transform is applied to an element it gets its own stacking order and a transaletZ combined with transform-style: preserve-3d is needed to ensure the element maintains the higher z-order needed to appear over the top of other other elements.