### PR TITLE
Add modern test helpers

### DIFF
--- a/addon-test-support/drag.js
+++ b/addon-test-support/drag.js
@@ -1,0 +1,61 @@
+import { triggerEvent } from '@ember/test-helpers';
+
+export default async function drag(mode, item, offsetFn, callbacks = {}) {
+  let start, move, end, which;
+
+  if (mode === 'mouse') {
+    start = 'mousedown';
+    move = 'mousemove';
+    end = 'mouseup';
+    which = 1;
+  } else if (mode === 'touch') {
+    start = 'touchstart';
+    move = 'touchmove';
+    end = 'touchend';
+  } else {
+    throw new Error(`Unsupported mode: '${mode}'`);
+  }
+
+  const itemOffset = {
+    left: item.offsetLeft,
+    top: item.offsetTop
+  };
+  const offset = offsetFn();
+  const rect = item.getBoundingClientRect();
+  const scale = item.clientHeight / (rect.bottom - rect.top);
+  const targetX = itemOffset.left + offset.dx * scale;
+  const targetY = itemOffset.top + offset.dy * scale;
+
+  await triggerEvent(item, start, {
+    clientX: itemOffset.left,
+    clientY: itemOffset.top,
+    which
+  });
+
+  if (callbacks.dragstart) {
+    await callbacks.dragstart;
+  }
+
+  await triggerEvent(item, move, {
+    clientX: itemOffset.left,
+    clientY: itemOffset.top
+  });
+
+  if (callbacks.dragmove) {
+    await callbacks.dragmove;
+  }
+
+  await triggerEvent(item, move, {
+    clientX: targetX,
+    clientY: targetY
+  });
+
+  await triggerEvent(item, end, {
+    clientX: targetX,
+    clientY: targetY
+  });
+
+  if (callbacks.dragend) {
+    await callbacks.dragend;
+  }
+}

--- a/addon-test-support/reorder.js
+++ b/addon-test-support/reorder.js
@@ -1,0 +1,21 @@
+import { findAll } from '@ember/test-helpers';
+import drag from './drag';
+
+export default async function reorder(mode, itemSelector, ...resultSelectors) {
+  const items = findAll(itemSelector);
+
+  await resultSelectors.reduce(async (acc, selector, targetIndex) => {
+    await acc;
+
+    const element = items.find(item => item.matches(selector));
+    const targetElement = items[targetIndex];
+    const dx = targetElement.offsetLeft - element.offsetLeft;
+    const dy = targetElement.offsetTop - element.offsetTop;
+
+    if (dx === 0 && dy === 0) {
+      return Promise.resolve();
+    }
+
+    return drag(mode, element, () => ({ dx, dy }));
+  }, Promise.resolve());
+}


### PR DESCRIPTION
This adds an `async/await`-friendly version of the `drag` and `reorder` test helpers, that compose better with the "modern" test helpers provided by `@ember/test-helpers`.

I'm not sure if the `offsetLeft` and `offsetTop` properties will work in all browsers, but it does work in Chrome. I opted for this approach so that this doesn't depend on `jQuery` in any way. If you'd rather I put that back to the `jQuery`-full approach, I'm happy to do that.

Note: Because they're provided in `addon-test-support` they would be imported like

```javascript
import drag from 'ember-sortable/test-support/drag';
import reorder from 'ember-sortable/test-support/reorder';
```