### PR TITLE
Don't break if A extensions are not enabled

### DIFF
--- a/addon/components/sortable-group.js
+++ b/addon/components/sortable-group.js
@@ -54,7 +54,7 @@ export default Component.extend({
     let items = a(this.get('items'));
     let direction = this.get('direction');
 
-    return items.sortBy(direction);
+    return a(items.sortBy(direction));
   }).volatile(),
 
   /**


### PR DESCRIPTION
Addon breaks in Ember 3.4 if Array extensions are disabled