### PR TITLE
Update links to use new owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![npm version](https://badge.fury.io/js/ember-sortable.svg)](http://badge.fury.io/js/ember-sortable)
 [![Ember Observer Score](http://emberobserver.com/badges/ember-sortable.svg)](http://emberobserver.com/addons/ember-sortable)
-[![Build Status](https://travis-ci.org/jgwhite/ember-sortable.svg?branch=master)](https://travis-ci.org/jgwhite/ember-sortable)
+[![Build Status](https://travis-ci.org/heroku/ember-sortable.svg?branch=master)](https://travis-ci.org/heroku/ember-sortable)
 [![Code Climate](https://codeclimate.com/github/jgwhite/ember-sortable/badges/gpa.svg)](https://codeclimate.com/github/jgwhite/ember-sortable)
 
 Sortable UI primitives for Ember.
 
-![ember-sortable in action](https://raw.githubusercontent.com/jgwhite/ember-sortable/master/demo.gif)
+![ember-sortable in action](/demo.gif)
 
-[Check out the demo](http://jgwhite.co.uk/ember-sortable/demo)
+[Check out the demo](https://heroku.github.io/ember-sortable/demo/)
 
 ## Requirements
 
@@ -239,7 +239,7 @@ import './ember-sortable/test-helpers';
 ### Setup
 
 ```sh
-$ git clone git@github.com:jgwhite/ember-sortable
+$ git clone git@github.com:heroku/ember-sortable
 $ cd ember-sortable
 $ ember install
 ```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "https://github.com/jgwhite/ember-sortable",
+  "repository": "https://github.com/heroku/ember-sortable",
   "scripts": {
     "build": "ember build",
     "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",
@@ -49,6 +49,6 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",
-    "demoURL": "http://jgwhite.co.uk/ember-sortable/demo/"
+    "demoURL": "https://heroku.github.io/ember-sortable/demo/"
   }
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -105,7 +105,7 @@
 
   <footer>
     <p>
-      <a href="https://github.com/jgwhite/ember-sortable">View on GitHub</a>
+      <a href="https://github.com/heroku/ember-sortable">View on GitHub</a>
     </p>
   </footer>
 </article>


### PR DESCRIPTION
First step to fully migrate this add-on under Heroku’s new ownership.

Fixes #199 