### PR TITLE
[bugfix] default `dx` and `dy` to 0 for drag helper

### DIFF
--- a/addon/helpers/drag.js
+++ b/addon/helpers/drag.js
@@ -60,12 +60,14 @@ export function drag(app, mode, itemSelector, offsetFn, callbacks = {}) {
     // https://bugzilla.mozilla.org/show_bug.cgi?id=874811#c14
     // https://stackoverflow.com/a/13647345
     // https://stackoverflow.com/a/5042051
+    let dx = offset.dx || 0;
+    let dy = offset.dy || 0;
     let clientHeight = (itemElement.clientHeight || item.offsetHeight) || itemElement.parentNode.offsetHeight;
     let scale = clientHeight / (rect.bottom - rect.top);
-    let halfwayX = itemOffset.left + (offset.dx * scale) / 2;
-    let halfwayY = itemOffset.top + (offset.dy * scale) / 2;
-    let targetX = itemOffset.left + (offset.dx * scale);
-    let targetY = itemOffset.top + (offset.dy * scale);
+    let halfwayX = itemOffset.left + (dx * scale) / 2;
+    let halfwayY = itemOffset.top + (dy * scale) / 2;
+    let targetX = itemOffset.left + (dx * scale);
+    let targetY = itemOffset.top + (dy * scale);
 
     andThen(() => {
       triggerEvent(itemElement, start, {

--- a/tests/acceptance/smoke-test.js
+++ b/tests/acceptance/smoke-test.js
@@ -79,16 +79,13 @@ test('reordering with mouse events', function(assert) {
     return item.offsetHeight + parseInt(itemStyle.marginTop);
   };
 
-  let itemWidth = () => {
-    let item = findWithAssert('.scrollable-demo .sortable-item');
-    return item.outerWidth() + parseInt(item.css('margin-left'));
-  };
-
   drag(
     'mouse',
     '.scrollable-demo .handle[data-item=Uno]',
     () => {
-      return { dy: itemHeight() + 1, dx: itemWidth() };
+      // leaving undefined dx so that we test that dx is set to zero by default
+      // otherwise an error will be thrown by the browser when trying to drag.
+      return { dy: itemHeight() + 1, dx: undefined };
     },
     {
       dragend: function() {


### PR DESCRIPTION
When using `drag` in tests, it's common to only drag vertically or
horizontaly, and leave either `dx` or `dy` undefined. When `dx` or `dy`
is undefined, the math calculated by the `drag` helper returns NaN
(because multiplying by undefined or null returns `NaN` instead), which
can throw errors when performing the drag in tests.

This fixes the helper by defaulting `dx` or `dy` to 0, a valid number,
instead.