### PR TITLE
getX and getY methods do provide now for non-wrapped events too (fixe…

### DIFF
--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -702,7 +702,7 @@ export default Mixin.create({
 */
 function getY(event) {
   let originalEvent = event.originalEvent;
-  let touches = originalEvent && originalEvent.changedTouches;
+  let touches = originalEvent? originalEvent.changedTouches : event.changedTouches;
   let touch = touches && touches[0];
 
   if (touch) {
@@ -720,7 +720,7 @@ function getY(event) {
 */
 function getX(event) {
   let originalEvent = event.originalEvent;
-  let touches = originalEvent && originalEvent.changedTouches;
+  let touches = originalEvent? originalEvent.changedTouches : event.changedTouches;
   let touch = touches && touches[0];
 
   if (touch) {


### PR DESCRIPTION
…s problem of silent error at _prepareDrag method happening in touch devices )