### PR TITLE
{{sortable-item}} as сlosure component

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ $ ember install ember-sortable
 
 {{#sortable-group tagName="ul" onChange=(action "reorderItems") as |group|}}
   {{#each model.items as |item|}}
-    {{#sortable-item tagName="li" model=item group=group handle=".handle"}}
+    {{#group.item tagName="li" model=item handle=".handle"}}
       {{item.name}}
       <span class="handle">&varr;</span>
-    {{/sortable-item}}
+    {{/group.item}}
   {{/each}}
 {{/sortable-group}}
 ```
@@ -66,10 +66,10 @@ with that group model as the first argument:
 
 {{#sortable-group tagName="ul" model=model onChange=(action "reorderItems") as |group|}}
   {{#each model.items as |item|}}
-    {{#sortable-item tagName="li" model=item group=group handle=".handle"}}
+    {{#group.item tagName="li" model=item handle=".handle"}}
       {{item.name}}
       <span class="handle">&varr;</span>
-    {{/sortable-item}}
+    {{/group.item}}
   {{/each}}
 {{/sortable-group}}
 ```
@@ -104,7 +104,7 @@ In `x` case: elements before current one jump to the left, and elements after cu
 To change this property, define `spacing` on `sortable-item` (default is `0`):
 
 ```hbs
-{{#sortable-item tagName="li" group=group spacing=15}}
+{{#group.item tagName="li" spacing=15}}
 ```
 
 ### Changing the drag tolerance
@@ -114,7 +114,7 @@ If specified, sorting will not start until after mouse is dragged beyond distanc
 Can be used to allow for clicks on elements within a handle.
 
 ```hbs
-{{#sortable-item group=group distance=30}}
+{{#group.item distance=30}}
 ```
 
 ### CSS, Animation
@@ -189,17 +189,17 @@ export default Ember.Route.extend({
 ```
 
 ```hbs
-  {{#sortable-item
+  {{#group.item
     onDragStart=(action "dragStarted")
     onDragStop=(action "dragStopped")
     tagName="li"
     model=item
-    group=group
+   
     handle=".handle"
   }}
     {{item.name}}
     <span class="handle">&varr;</span>
-  {{/sortable-item}}
+  {{/group.item}}
 ```
 
 ### Data down, actions up
@@ -216,10 +216,10 @@ Each item takes a `model` property. This should be fairly self-explanatory but i
 
 ```hbs
 {{#each myItems as |item idx| }}
-  {{#sortable-item tabindex=0 keyUp=(action 'keyUp' idx) tagName="li" model=item group=group handle=".handle"}}
+  {{#group.item tabindex=0 keyUp=(action 'keyUp' idx) tagName="li" model=item handle=".handle"}}
     {{item.name}}
     <span class="handle">&varr;</span>
-  {{/sortable-item}}
+  {{/group.item}}
 {{/each}}
 ```
 

--- a/addon/templates/components/sortable-group.hbs
+++ b/addon/templates/components/sortable-group.hbs
@@ -1,1 +1,1 @@
-{{yield this}}
+{{yield (hash item=(component "sortable-item" group=this))}}

--- a/testem.js
+++ b/testem.js
@@ -9,16 +9,14 @@ module.exports = {
     'Chrome'
   ],
   browser_args: {
-    Chrome: {
-      mode: 'ci',
-      args: [
+    Chrome: [
+      // mode: 'ci',
         '--disable-gpu',
         '--headless',
         '--no-sandbox',
         '--remote-debugging-port=0',
         '--window-size=1440,900'
-      ]
-    },
+    ],
     Firefox: {
       mode: 'ci',
       args: [

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -9,12 +9,12 @@
 
       {{#sortable-group tagName="ol" onChange="update" as |group|}}
         {{#each model.items as |item|}}
-          {{#sortable-item tagName="li" model=item group=group handle=".handle"}}
+          {{#group.item tagName="li" model=item handle=".handle"}}
             {{item}}
             <span class="handle" data-item={{item}}>
               <span>&vArr;</span>
             </span>
-          {{/sortable-item}}
+          {{/group.item}}
         {{/each}}
       {{/sortable-group}}
     </section>
@@ -24,9 +24,9 @@
 
       {{#sortable-group tagName="ol" direction="x" onChange="update" as |group|}}
         {{#each model.items as |item|}}
-          {{#sortable-item tagName="li" model=item group=group}}
+          {{#group.item tagName="li" model=item}}
             {{item-presenter item=item}}
-          {{/sortable-item}}
+          {{/group.item}}
         {{/each}}
       {{/sortable-group}}
 
@@ -45,10 +45,10 @@
         </thead>
         {{#sortable-group tagName="tbody" onChange="update" as |group|}}
           {{#each model.items as |item|}}
-            {{#sortable-item tagName="tr" model=item group=group handle=".handle"}}
+            {{#group.item tagName="tr" model=item handle=".handle"}}
               <td><span class="handle" data-item={{item}}>&vArr;</span></td>
               <td>{{item}}</td>
-            {{/sortable-item}}
+            {{/group.item}}
           {{/each}}
         {{/sortable-group}}
       </table>
@@ -59,11 +59,11 @@
 
       {{#sortable-group tagName="ol" onChange="update" as |group|}}
         {{#each model.items as |item|}}
-          {{#sortable-item tagName="li" model=item group=group spacing=15}}
+          {{#group.item tagName="li" model=item spacing=15}}
             {{item}}
             <span class="handle" data-item={{item}}>
             </span>
-          {{/sortable-item}}
+          {{/group.item}}
         {{/each}}
       {{/sortable-group}}
     </section>
@@ -73,11 +73,11 @@
 
       {{#sortable-group tagName="ol" onChange="update" as |group|}}
         {{#each model.items as |item|}}
-          {{#sortable-item tagName="li" model=item group=group distance=15}}
+          {{#group.item tagName="li" model=item distance=15}}
             {{item}}
             <span class="handle" data-item={{item}}>
             </span>
-          {{/sortable-item}}
+          {{/group.item}}
         {{/each}}
       {{/sortable-group}}
     </section>
@@ -88,12 +88,12 @@
       <div class="sortable-container">
         {{#sortable-group tagName="ol" onChange="update" as |group|}}
           {{#each model.items as |item|}}
-            {{#sortable-item tagName="li" model=item group=group handle=".handle"}}
+            {{#group.item tagName="li" model=item handle=".handle"}}
               {{item}}
               <span class="handle" data-item={{item}}>
                 <span>&vArr;</span>
               </span>
-            {{/sortable-item}}
+            {{/group.item}}
           {{/each}}
         {{/sortable-group}}
       </div>

--- a/tests/integration/components/sortable-group-test.js
+++ b/tests/integration/components/sortable-group-test.js
@@ -10,9 +10,9 @@ moduleForComponent('sortable-group', 'Integration | Component | sortable group',
 test('distance attribute prevents the drag before the specified value', async function(assert) {
   this.render(hbs`
     {{#sortable-group as |group|}}
-      {{#sortable-item distance=15 model=1 group=group id="dummy-sortable-item"}}
+      {{#group.item distance=15 model=1 id="dummy-sortable-item"}}
         {{item}}
-      {{/sortable-item}}
+      {{/group.item}}
     {{/sortable-group}}
   `);
 
@@ -34,9 +34,9 @@ test('distance attribute prevents the drag before the specified value', async fu
 test('sortable-items have tabindexes for accessibility', function (assert) {
   this.render(hbs`
     {{#sortable-group as |group|}}
-      {{#sortable-item tabindex=0 model=1 id="dummy-sortable-item"}}
+      {{#group.item tabindex=0 model=1 id="dummy-sortable-item"}}
         sort me
-      {{/sortable-item}}
+      {{/group.item}}
     {{/sortable-group}}
   `);
 


### PR DESCRIPTION
PR changes `{{sortable-group}} ` so it now yields `{{sortable-item}}`:

```hbs
{{#sortable-group onChange=(action "reorderItems") as |group|}}
  {{#each model.items as |item|}}
    {{#group.item model=item handle=".handle"}}
      {{item.name}}
      <span class="handle">&varr;</span>
    {{/sortable-item}}
  {{/each}}
{{/sortable-group}}
```

---

## Why:
 - cleaner and more flexible API since all `group<=>item` communication details can now be hidden from addon user
 - easy of future improvements (for example #154)

## Downsides:
 - backwards incompatible*
 - dropping Ember <2.4 support (6% of users according to [latest survey](https://emberjs.com/ember-community-survey-2019/))

   
`*` this may be done backwards compatible but with a bit weird API