### PR TITLE
Fix subtle bug in sortable-item#thaw

### DIFF
--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -323,7 +323,7 @@ export default Mixin.create({
     let el = this.element;
     if (!el) { return; }
 
-    el.style.transform = '';
+    el.style.transition = '';
   },
 
   /**


### PR DESCRIPTION
In the shift to a jQuery-less future this method wasn’t converted quite correctly.

Fixes #240 