### PR TITLE
Add Ember 2.8, 2.12 to testing. Test Node 8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "6"
+  - "8"
 
 sudo: false
 dist: trusty
@@ -50,7 +50,9 @@ jobs:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
     - stage: "Additional Tests"
-      env: EMBER_TRY_SCENARIO=ember-lts-2.18
+      env: EMBER_TRY_SCENARIO=ember-lts-2.8
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.12
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.18
     - env: EMBER_TRY_SCENARIO=ember-lts-3.4
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -12,6 +12,34 @@ module.exports = function() {
       useYarn: true,
       scenarios: [
         {
+          name: 'ember-lts-2.8',
+          env: {},
+          bower: {
+            dependencies: {
+              ember: 'components/ember#lts-2-8',
+            },
+            resolutions: {
+              ember: 'lts-2-8',
+            },
+          },
+          npm: {
+            devDependencies: {
+              '@ember/jquery': '^0.5.1',
+              'ember-source': null,
+            }
+          },
+        },
+        {
+          name: 'ember-lts-2.12',
+          env: {},
+          npm: {
+            devDependencies: {
+              '@ember/jquery': '^0.5.1',
+              'ember-source': '~2.12.0'
+            }
+          }
+        },
+        {
           name: 'ember-lts-2.18',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true })


### PR DESCRIPTION
I'd like to ensure ember-sortable remains backwards compatible to Ember 1.12. I'd welcome any feedback from maintainers about if that is something they are OK with, or if not then to get some reasoning about what the base version should be.

Regardless this PR is an incremental change to add Ember 2.8 and 2.12 support to the test suite. I'll follow up on any failures.

