### PR TITLE
eslint: enforce space before and after arrow of arrow function

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,8 @@ module.exports = {
     browser: true
   },
   rules: {
-    'ember/closure-actions': 'off'
+    'ember/closure-actions': 'off',
+    'arrow-spacing': 'error'
   },
   overrides: [
     // node files


### PR DESCRIPTION
Have eslint enforce that we want `() => {}` not `()=>{}`