### PR TITLE
[BUGFIX] fixes bug when sorting to the beginning of list

### DIFF
--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -708,7 +708,7 @@ function getY(event) {
   if (touch) {
     return touch.screenY;
   } else {
-    return event.clientY;
+    return event.clientY || event.pageY;
   }
 }
 
@@ -725,7 +725,7 @@ function getX(event) {
   if (touch) {
     return touch.screenX;
   } else {
-    return event.clientX;
+    return event.clientX || event.pageX;
   }
 }
 


### PR DESCRIPTION
When using ember-sortable inside a list that scrolls, the `getY / getX` function inside sortable-item mixin returns `undefined` causing the calculation of item position to get confused and ultimately end up being `NaN`. The reason it gets mixed up is because the event being passed into `getY(event)` has the property `pageY` instead of the (currently) expected `clientY`. This PR fixes the `undefined` by giving priority to `clientY/clientX` while falling back to `pageY/pageX`

Where getY is getting called with the wrong event. 
https://github.com/heroku/ember-sortable/blob/master/addon/mixins/sortable-item.js#L536
Originating from:
https://github.com/heroku/ember-sortable/blob/master/addon/mixins/sortable-item.js#L489

Before: 
https://screencast-o-matic.com/watch/cqQ0oLtRJD

After: 
https://screencast-o-matic.com/watch/cqQ0o8tRJz
